### PR TITLE
Add a no-argument constructor for the RangeSlider

### DIFF
--- a/range-slider-component/src/main/java/com/github/daishy/rangeslider/RangeSlider.java
+++ b/range-slider-component/src/main/java/com/github/daishy/rangeslider/RangeSlider.java
@@ -27,6 +27,14 @@ public class RangeSlider extends AbstractJavaScriptComponent implements HasValue
      * The current value of the field.
      */
     private Range value;
+    
+    /**
+     * Create the new range-slider. The value of this field is initialized with a (0, 0) boundary.
+     * This no-argument constructor is necessary for Vaadin to auto-bind html to Java components.
+     *     */
+    public RangeSlider() {
+        this(new Range());
+    }
 
     /**
      * Create the new range-slider. The value of this field is initialized with the given boundary.


### PR DESCRIPTION
A no-argument constructor is needed for Vaadin to auto-bind an html element with a Java component. The default RangeSlider is created with a (0, 0) Range.